### PR TITLE
Update event_questions.rb

### DIFF
--- a/db/seeds/event_questions.rb
+++ b/db/seeds/event_questions.rb
@@ -25,6 +25,7 @@ Event::Question.where(event_id: nil).destroy_all
   eq = Event::Question.find_or_initialize_by(
     event_id: attrs.delete(:event_id),
     question: attrs.delete(:question),
+    required: true,
   )
   eq.attributes = attrs
   eq.save!


### PR DESCRIPTION
Wenn ich einen neuen Kurs erstelle. Wird in den Kursangaben die vordefinierten Fragen beim Pflichtfeld automatisch auf checked gesetzt.